### PR TITLE
Don't loop on retry count

### DIFF
--- a/OidcApiAuthorization/OidcApiAuthorizationService.cs
+++ b/OidcApiAuthorization/OidcApiAuthorizationService.cs
@@ -140,7 +140,7 @@ namespace OidcApiAuthorization
                         + $"Message: {ex.Message}");
                 }
 
-            } while (!isTokenValid && validationRetryCount <= 1);
+            } while (!isTokenValid);
 
             // Success result.
             return new ApiAuthorizationResult();


### PR DESCRIPTION
The loop for validating the token should only exit normally if the token is valid. Exceeding the retry count will exit that loop via return statements in catch blocks.