### PR TITLE
Use `FunctionsPreservedDependencies` to resolve "Could not load file or assembly" errors

### DIFF
--- a/SampleFunctionApp/SampleFunctionApp.csproj
+++ b/SampleFunctionApp/SampleFunctionApp.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- 
-      Use FunctionsPreservedDependencies to perserve assemblies that are used in OidcApiAuthorization
+      Use FunctionsPreservedDependencies to preserve assemblies that are used in OidcApiAuthorization
       and are more rescent versions than are used in the Azure Functions run-time.
       See https://docs.microsoft.com/en-us/azure/azure-functions/functions-develop-vs#configure-your-build-output-settings
       This is an alternative to using `<_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>`

--- a/SampleFunctionApp/SampleFunctionApp.csproj
+++ b/SampleFunctionApp/SampleFunctionApp.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OidcApiAuthorization\OidcApiAuthorization.csproj" />

--- a/SampleFunctionApp/SampleFunctionApp.csproj
+++ b/SampleFunctionApp/SampleFunctionApp.csproj
@@ -5,9 +5,12 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- 
-      Use FunctionsPreservedDependencies to perserve assemblies are more rescent versions
-      than are used in OidcApiAuthorization than in the Azure Functions run-time.
+      Use FunctionsPreservedDependencies to perserve assemblies that are used in OidcApiAuthorization
+      and are more rescent versions than are used in the Azure Functions run-time.
       See https://docs.microsoft.com/en-us/azure/azure-functions/functions-develop-vs#configure-your-build-output-settings
+      This is an alternative to using `<_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>`
+      which is undocumented, but sometimes recommended. For example see:
+      https://github.com/Azure/azure-functions-vs-build-sdk/issues/397
     -->
     <FunctionsPreservedDependencies Include="Microsoft.IdentityModel.JsonWebTokens.dll" />
     <FunctionsPreservedDependencies Include="Microsoft.IdentityModel.Logging.dll" />

--- a/SampleFunctionApp/SampleFunctionApp.csproj
+++ b/SampleFunctionApp/SampleFunctionApp.csproj
@@ -2,8 +2,20 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
-	<_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
   </PropertyGroup>
+  <ItemGroup>
+    <!-- 
+      Use FunctionsPreservedDependencies to perserve assemblies are more rescent versions
+      than are used in OidcApiAuthorization than in the Azure Functions run-time.
+      See https://docs.microsoft.com/en-us/azure/azure-functions/functions-develop-vs#configure-your-build-output-settings
+    -->
+    <FunctionsPreservedDependencies Include="Microsoft.IdentityModel.JsonWebTokens.dll" />
+    <FunctionsPreservedDependencies Include="Microsoft.IdentityModel.Logging.dll" />
+    <FunctionsPreservedDependencies Include="Microsoft.IdentityModel.Protocols.dll" />
+    <FunctionsPreservedDependencies Include="Microsoft.IdentityModel.Protocols.OpenIdConnect.dll" />
+    <FunctionsPreservedDependencies Include="Microsoft.IdentityModel.Tokens.dll" />
+    <FunctionsPreservedDependencies Include="System.IdentityModel.Tokens.Jwt.dll" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />


### PR DESCRIPTION
Use `FunctionsPreservedDependencies` instead of `_FunctionsSkipCleanOutput` to resolve "Could not load file or assembly" errors.

For some info about `FunctionsPreservedDependencies`, see:
https://docs.microsoft.com/en-us/azure/azure-functions/functions-develop-vs#configure-your-build-output-settings

This approach is a possible means to address Issue: #27 