### PR TITLE
I37 not working with net 6

### DIFF
--- a/.github/workflows/dotnetcore-ci.yml
+++ b/.github/workflows/dotnetcore-ci.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.102
+        dotnet-version: '6.0.x'
 
     # Build the solution.
     - name: Build solution with dotnet

--- a/OidcApiAuthorization.TestFixtures/OidcApiAuthorization.TestFixtures.csproj
+++ b/OidcApiAuthorization.TestFixtures/OidcApiAuthorization.TestFixtures.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OidcApiAuthorization.TestFixtures/OidcApiAuthorization.TestFixtures.csproj
+++ b/OidcApiAuthorization.TestFixtures/OidcApiAuthorization.TestFixtures.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="3.1.18" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\OidcApiAuthorization\OidcApiAuthorization.csproj" />
     <ProjectReference Include="..\TestFixtures.AzureFunctions\TestFixtures.AzureFunctions.csproj" />
   </ItemGroup>

--- a/OidcApiAuthorization.Tests/OidcApiAuthorization.Tests.csproj
+++ b/OidcApiAuthorization.Tests/OidcApiAuthorization.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/OidcApiAuthorization.Tests/OidcApiAuthorization.Tests.csproj
+++ b/OidcApiAuthorization.Tests/OidcApiAuthorization.Tests.csproj
@@ -8,13 +8,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/OidcApiAuthorization/OidcApiAuthorization.csproj
+++ b/OidcApiAuthorization/OidcApiAuthorization.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OidcApiAuthorization/OidcApiAuthorization.csproj
+++ b/OidcApiAuthorization/OidcApiAuthorization.csproj
@@ -5,12 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="3.1.18" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="5.0.14" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.18" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols" Version="6.12.1" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.12.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.12.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols" Version="6.15.1" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.15.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.15.1" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Service providers that support compatible authorization servers include [Auth0](
 
 # This Sample Uses:
 - C#
-- .NET Core v3.1
-- Azure Functions v3
+- .NET 6
+- Azure Functions v4
 - [Dependency Injection](https://docs.microsoft.com/en-us/azure/azure-functions/functions-dotnet-dependency-injection)
 - [Options Pattern for App Settings](https://docs.microsoft.com/en-us/azure/azure-functions/functions-dotnet-dependency-injection#working-with-options-and-settings)
 - OpenIDConnect (OIDC), Bearer tokens (OAuth 2.0 JSON Web Tokens (JWT))

--- a/SampleFunctionApp.Tests/SampleFunctionApp.Tests.csproj
+++ b/SampleFunctionApp.Tests/SampleFunctionApp.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/SampleFunctionApp.Tests/SampleFunctionApp.Tests.csproj
+++ b/SampleFunctionApp.Tests/SampleFunctionApp.Tests.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/SampleFunctionApp/SampleFunctionApp.csproj
+++ b/SampleFunctionApp/SampleFunctionApp.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <!--
     The `<_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>` is needed to preserve

--- a/SampleFunctionApp/SampleFunctionApp.csproj
+++ b/SampleFunctionApp/SampleFunctionApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <!--
     The `<_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>` is needed to preserve
     all assemblies used by the function app even if they have the same name as assemblies used 
@@ -23,7 +23,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OidcApiAuthorization\OidcApiAuthorization.csproj" />

--- a/TestFixtures.AzureFunctions/TestFixtures.AzureFunctions.csproj
+++ b/TestFixtures.AzureFunctions/TestFixtures.AzureFunctions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestFixtures.AzureFunctions/TestFixtures.AzureFunctions.csproj
+++ b/TestFixtures.AzureFunctions/TestFixtures.AzureFunctions.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.27" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.12.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.15.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Changed `TargetFramework` to `net6.0`.
- Changed `AzureFunctionsVersion` to `v4`.
- Updated NuGet packages to latest stable release.
- No code changes for C# 10.

#37 